### PR TITLE
remove Accept-Encoding=gzip header from HTTP client config

### DIFF
--- a/sdk/src/main/java/mil/nga/giat/mage/sdk/http/HttpClientManager.java
+++ b/sdk/src/main/java/mil/nga/giat/mage/sdk/http/HttpClientManager.java
@@ -90,9 +90,7 @@ public class HttpClientManager implements IEventDispatcher<ISessionEventListener
                     builder.addHeader("Authorization", "Bearer " + token);
                 }
 
-                // add Accept-Encoding:gzip
-                builder.addHeader("Accept-Encoding", "gzip")
-                    .addHeader("User-Agent", userAgent);
+                builder.addHeader("User-Agent", userAgent);
 
                 Response response = chain.proceed(builder.build());
 


### PR DESCRIPTION
Having this header in place does the opposite of what one might expect. When this header is set, `okhttp` will specifically _not_ un-gzip response content. Setting this header means "I want to handle un-gzipping on my own".

Perhaps this was intentional, though? I don't know -- but I had to remove this header in order to hit our MAGE API where we are gzipping the response content (via NGINX). 

As a workaround for us, we could disable gzipping for MAGE-related calls through NGINX, but we'd prefer to leave it enabled for obvious reasons.